### PR TITLE
Fix Java-specific issues and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Hi and welcome to team Gilded Rose. As you know, we are a small inn with a prime
 
 - The Quality of an item is never negative
 
-- "Aged" items actually increases in Quality the older they get
+- "Aged" items actually increase in Quality the older they get
 
 - The Quality of an item is never more than 50, unless "Legendary"
 

--- a/src/main/java/com/kajabi/gildedrose/GildedRose.java
+++ b/src/main/java/com/kajabi/gildedrose/GildedRose.java
@@ -24,16 +24,16 @@ public class GildedRose {
   }
 
   public void tick() {
-    if (this.name != "Aged Brie" && this.name != "Backstage passes to a TAFKAL80ETC concert") {
+    if (!this.name.equals("Aged Brie") && !this.name.equals("Backstage passes to a TAFKAL80ETC concert")) {
       if (this.quality > 0) {
-        if (this.name != "Legendary Sulfuras, Hand of Ragnaros") {
+        if (!this.name.equals("Legendary Sulfuras, Hand of Ragnaros")) {
           this.quality--;
         }
       }
     } else {
       if (this.quality < 50) {
         this.quality++;
-        if (this.name == "Backstage passes to a TAFKAL80ETC concert") {
+        if (this.name.equals("Backstage passes to a TAFKAL80ETC concert")) {
           if (this.daysRemaining < 11) {
             if (this.quality < 50) {
               this.quality++;
@@ -47,14 +47,14 @@ public class GildedRose {
         }
       }
     }
-    if (this.name != "Legendary Sulfuras, Hand of Ragnaros") {
+    if (!this.name.equals("Legendary Sulfuras, Hand of Ragnaros")) {
       this.daysRemaining--;
     }
     if (this.daysRemaining < 0) {
-      if (this.name != "Aged Brie") {
-        if (this.name != "Backstage passes to a TAFKAL80ETC concert") {
+      if (!this.name.equals("Aged Brie")) {
+        if (!this.name.equals("Backstage passes to a TAFKAL80ETC concert")) {
           if (this.quality > 0) {
-            if (this.name != "Legendary Sulfuras, Hand of Ragnaros") {
+            if (!this.name.equals("Legendary Sulfuras, Hand of Ragnaros")) {
               this.quality--;
             }
           }

--- a/src/test/java/com/kajabi/gildedrose/GildedRoseTest.java
+++ b/src/test/java/com/kajabi/gildedrose/GildedRoseTest.java
@@ -311,21 +311,21 @@ public class GildedRoseTest {
     StringBuilder errorBuilder = new StringBuilder();
 
     boolean daysRemainingError = daysRemaining != rose.getDaysRemaining();
-    if (daysRemainingError == true) {
+    if (daysRemainingError) {
       errorBuilder.append("Expected daysRemaining <").append(daysRemaining).append("> but was <")
           .append(rose.getDaysRemaining()).append(">.");
     }
 
     boolean qualityError = quality != rose.getQuality();
-    if (qualityError == true) {
-      if (daysRemainingError == true) {
+    if (qualityError) {
+      if (daysRemainingError) {
         errorBuilder.append(" ");
       }
       errorBuilder.append("Expected quality <").append(quality).append("> but was <").append(rose.getQuality())
           .append(">.");
     }
 
-    if (qualityError == true || daysRemainingError == true) {
+    if (qualityError || daysRemainingError) {
       throw new AssertionFailedError(errorBuilder.toString());
     }
   }


### PR DESCRIPTION
Fixed a minor grammar issue in the README (It's present in the other repos, too 😢 ). 

Speaking of the README, we may want to clarify the description to say that aged items also increase in quality twice as fast after the due date. This came up in a coding interview today. Yes, the applicant found the answer in the tests, but the README could be clearer on this point.

Simplified booleans in the test - no need to compare a boolean value to `true` when we can evaluate the boolean itself. I'd leave this alone if this was something we intended the applicant to notice/fix, but that's not evident that it's the case.

Also, and most importantly, fixed how we're checking equality on the strings. It's a bit of luck that the tests pass with these equals methods in the first place. We want to use `.equals` to compare values rather than `==` to compare the references.

If this was intentional, as something to ensure the Java developers notice it, we can leave it in, but I found it distracting from the real refactoring of simplifying the `if` statements. And these equality questions aren't present on the other language versions.